### PR TITLE
Fix sitemap generation by including appropriate default storage backend

### DIFF
--- a/settings_local.py
+++ b/settings_local.py
@@ -1,7 +1,7 @@
-
 # Turn off immutable static file names
 STORAGES = {
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
 }


### PR DESCRIPTION
Wagtail checks for a storage backend on boot, and up until now we only had one defined for staticfiles

